### PR TITLE
[Fix] - Style fixes and RTL styles

### DIFF
--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -90,3 +90,9 @@ code {
   left: -999em;
   right: auto;
 }
+
+[dir='rtl'] .sr-only {
+  position: absolute;
+  right: -999em;
+  left: auto;
+}

--- a/src/css/scheme-default.css
+++ b/src/css/scheme-default.css
@@ -54,14 +54,18 @@
   --color-primary: #005EA2;
   --color-primary-light-x: #2378C3;
   --color-primary-light-xx: #25B6E2;
-  --color-primary-light-xxx: #EFF6FB;
+  --color-primary-light-xxx: #d8e8f4;
 
   --color-secondary-dark-xx: #204E34;
   --color-secondary-dark-x: #286846;
   --color-secondary: #34A37E;
   --color-secondary-light-x: #3db37e;
   --color-secondary-light-xx: #4BD6A7;
+  --color-secondary-light-xxx: #ceefe4;
 
+  --color-error: #df2626;
+  --color-error-light: #eec1c1;
+  
   /* Striped Backgrounds */
 
   --background-striped-primary-dark-xx: repeating-linear-gradient(

--- a/src/stories/Molecules/Alert/Alert.css
+++ b/src/stories/Molecules/Alert/Alert.css
@@ -44,8 +44,22 @@
   display: block;
 }
 
-.alert__content ul, .alert__content ol {
+.alert__content ul, 
+.alert__content ol {
   list-style-position: outside;
+  margin-inline-start: 0;
+}
+
+.alert__content-single > .alert__content__inner {
+  margin-inline-start: var(--s-3);
+  display: inline-flex;;
+}
+
+.alert__content-single .alert__content__heading {
+  margin-inline-end: var(--s-5);
+}
+
+.alert__content-multiple .alert__content__heading {
   margin-inline-start: var(--s2);
 }
 
@@ -75,4 +89,28 @@
 .alert__dismiss {
   margin-inline-start: auto;
   margin-block-start: var(--s-6);
+}
+
+/* Alerts inside of a layout section paragraph. */
+.section .alert {
+  border-inline-start: var(--s-2) solid var(--color-primary-light-xx);
+  background-color: var(--color-primary-light-xxx);
+  color: var(--color);
+}
+
+.section .alert[data-alert-type="status"] {
+  --color: var(--color-black);
+  border-inline-start: var(--s-2) solid var(--color-secondary-light-xx);
+  background-color: var(--color-secondary-light-xxx);
+}
+
+.section .alert[data-alert-type="warning"] {
+  border-inline-start: var(--s-2) solid var(--color-accent-warm-light-x);
+  background-color: var(--color-accent-warm-light-xxx);
+}
+
+.section .alert[data-alert-type="error"] {
+  --color: var(--color-black);
+  border-inline-start: var(--s-2) solid var(--color-error);
+  background-color: var(--color-error-light);
 }

--- a/src/stories/Molecules/Alert/Alert.data.js
+++ b/src/stories/Molecules/Alert/Alert.data.js
@@ -3,6 +3,7 @@ export default {
     variant: "default",
     type: "info",
     icon_data: {},
+    heading: '',
     content: [
       "<p>In Drupal this is an array of messages.</p>", 
       "<p>This is another message.</p>", 

--- a/src/stories/Molecules/Alert/Alert.stories.js
+++ b/src/stories/Molecules/Alert/Alert.stories.js
@@ -24,10 +24,6 @@ export default {
       table: { disable: true },
       control: false,
     },
-    content: {
-      table: { disable: true },
-      control: false,
-    },
     icon_data: {
       table: { disable: true },
       control: false,

--- a/src/stories/Molecules/Alert/Alert.twig
+++ b/src/stories/Molecules/Alert/Alert.twig
@@ -13,24 +13,27 @@
   color: icon_data.color,
 } %}
 
+{% set content_class = content|length > 1 ? 'alert__content-multiple' : 'alert__content-single' %}
+
 <div class="{{ classes|join(' ') }}" data-alert-type="{{ type }}" data-alert-dismissible="{{ dismissible }}">
   <div class="container">
     {% include "@atoms/Icon/Icon.twig" with icon_data %}
 
-    <div class="alert__content">
-      {% if heading is not empty %}
-        <p><strong>{{ heading }}</strong></p>
-      {% endif %}
-
+    <div class="alert__content {{ content_class }}">
+      <div class="alert__content__inner">
       {% if content|length > 1 %}
+        {% if heading is not empty %}
+          <p class="alert__content__heading"><strong>{{ heading }}</strong></p>
+        {% endif %}
         <ul>
           {% for message in content %}
             <li>{{ message }}</li>
           {% endfor %}
         </ul>
       {% else %}
-        {{ content|first }}
+        {% if heading is not empty %}<span class="alert__content__heading"><strong>{{ heading }}</strong></span>{% endif %} {{ content|first }}
       {% endif %}
+      </div>
     </div>
 
     {% if dismissible %}

--- a/src/stories/Molecules/Breadcrumb/Breadcrumb.css
+++ b/src/stories/Molecules/Breadcrumb/Breadcrumb.css
@@ -1,10 +1,12 @@
 .breadcrumb {
   background-color: var(--color-accent-warm-light-xxxx);
   --gap: 0.5rem;
+  padding-inline: var(--s0);
 }
 
 .breadcrumb__list {
   list-style-type: none;
+  padding-inline: 0;
 }
 
 .breadcrumb__item {

--- a/src/stories/Molecules/MediaExcerpt/MediaExcerpt.css
+++ b/src/stories/Molecules/MediaExcerpt/MediaExcerpt.css
@@ -29,6 +29,7 @@
   font-size: var(--s-1);
   list-style: none;
   row-gap: 0;
+  padding-inline:0;
 }
 
 .media-excerpt .detail-list > * + *::before {

--- a/src/stories/Molecules/Pager/Pager.css
+++ b/src/stories/Molecules/Pager/Pager.css
@@ -50,3 +50,13 @@
   > div {
   stroke: var(--accent-color);
 }
+
+[dir='rtl'] .pager__item:is(.pager__item--first, .pager__item--previous) a > div {
+  padding-inline: var(--s-3) 0;
+  rotate: 180deg;
+}
+
+[dir='rtl'] .pager__item:is(.pager__item--first, .pager__item--next) a > div {
+  padding-inline: 0 var(--s-3);
+  rotate: 180deg;
+}

--- a/src/stories/Organisms/TeaserPlusList/TeaserPlusList.css
+++ b/src/stories/Organisms/TeaserPlusList/TeaserPlusList.css
@@ -26,6 +26,7 @@
 
 .teaser-list__list ul {
   list-style: none;
+  padding-inline: 0;
 }
 
 .teaser-list__footer {


### PR DESCRIPTION
[Fix] - 

Style fixes and RTL styles

Adds new colors for alerts inside of a layout section. 
Sets headings for alerts to be inline with first message if there is only 1 message.
Fixes padding issues to any special UL or OL list based components, like alerts, breadcrumbs, and pagers.
Sets RTL style fixes for pagers, breadcrumbs, alerts, etc.