### PR TITLE
[DCAS-36] -- Added a setup to try to set ordered and unordered lists …

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -31,7 +31,7 @@ export const parameters = {
   },
   options: {
     storySort: {
-      order: ['Documentation', ['Intro'], 'Scheme', ['Colors', 'Fonts', 'Sizes'], 'Atoms', 'Molecules', 'Organisms', 'Templates', 'Pages', 'Layout'],
+      order: ['Documentation', ['Intro'], 'Scheme', ['Colors', 'Fonts', 'Sizes', 'Text'], 'Atoms', 'Molecules', 'Organisms', 'Templates', 'Pages', 'Layout'],
     },
   },
   rtlDirection: {

--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -100,6 +100,23 @@ table th {
   text-align: left;
 }
 
+hr {
+  border: 0;
+  border-block-end: 1px solid var(--color-base-light-x);
+}
+
+dl dd + dt {
+  margin-block-start: var(--s0);
+}
+
+dt, dfn {
+  font-weight: 600;
+}
+
+dd {
+  margin-inline-start: var(--s1);
+}
+
 /* Screen Reader Only */
 .sr-only {
   position: absolute;

--- a/src/stories/Scheme/LegalFormatting/LegalFormatting.css
+++ b/src/stories/Scheme/LegalFormatting/LegalFormatting.css
@@ -1,0 +1,71 @@
+/* Ordered list styles */
+.legal ol {
+  counter-reset: list;
+}
+
+.legal li + li {
+  margin-block-start: var(--s-6);
+}
+
+.legal li + li > ol,
+.legal li + li > ul {
+  margin-block: var(--s1);
+}
+
+.legal ol > li {
+  list-style: none;
+}
+
+.legal ol li::marker,
+.legal ul li::marker {
+  font-weight: 600;
+}
+
+.legal ol > li:before {
+  width: var(--s2);
+  display: inline-block;
+  margin-inline-start: calc(var(--s2) * -1);
+  margin-inline-end: var(--s-3);
+  font-weight: 600;
+  text-align: end;
+  counter-increment: list;
+  content: "(" counter(list, lower-alpha) ")";
+}
+
+.legal li li li li li ol > li:before {
+  content: "(" counter(list, upper-roman) ")";
+}
+
+.legal li li li li ol > li:before {
+  content: "(" counter(list, upper-alpha) ")";
+}
+
+.legal li li li ol > li:before {
+  content: "(" counter(list, decimal-leading-zero) ")";
+}
+
+.legal li li ol > li:before {
+  content: "(" counter(list, lower-roman) ")";
+}
+
+.legal li ol > li:before {
+  content: "(" counter(list, decimal) ")";
+}
+
+.legal ol > li:before {
+  content: "(" counter(list, lower-alpha) ")";
+}
+
+/* Unordered list styles */
+.legal ul > li ul > li ul > li {
+  list-style-type: circle;
+}
+
+.legal ul > li ul > li {
+  list-style-type: square;
+}
+
+.legal li ul > li,
+.legal ul > li {
+  list-style-type: disc;
+}

--- a/src/stories/Scheme/LegalFormatting/LegalFormatting.stories.js
+++ b/src/stories/Scheme/LegalFormatting/LegalFormatting.stories.js
@@ -1,0 +1,21 @@
+import readme from './readme.md';
+import LegalFormatting from './LegalFormatting.twig';
+import './LegalFormatting.css';
+
+export default {
+  title: 'Scheme/LegalFormatting',
+  component: LegalFormatting,
+  parameters: {
+    notes: readme,
+    layout: 'padded',
+  },
+};
+
+// Create Template for variant templates to bind to.
+const Template = ({ ...args }) => {
+  return LegalFormatting({ ...args });
+};
+
+// Bind the Default component variant for this component.
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/stories/Scheme/LegalFormatting/LegalFormatting.twig
+++ b/src/stories/Scheme/LegalFormatting/LegalFormatting.twig
@@ -1,0 +1,87 @@
+{% set classes = [
+  'text',
+  'field',
+  'stack',
+] %}
+
+<div class="{{ classes|join(' ') }}" style="max-width: var(--measure);">
+
+  <h2>Legal formatted list items</h2>
+
+  <p>The class <strong>"legal"</strong> needs to be applied to some parent of the
+  list to trigger the "Legal" styles. This is a mixed example of nested ordered 
+  and unordered list items</p>
+
+  <div class="legal">
+    <ol>
+      <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+      <li>Conferam tecum, quam cuique verso rem subicias;
+        <ol>
+            <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+            <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?
+              <ol>
+                <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                <li>Conferam tecum, quam cuique verso rem subicias;</li>
+              </ol>
+            </li>
+            <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+            <li>Conferam tecum, quam cuique verso rem subicias;
+              <ol>
+                <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?
+                  <ul>
+                    <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                    <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                    <li>Conferam tecum, quam cuique verso rem subicias;
+                      <ol>
+                        <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                        <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                        <li>Conferam tecum, quam cuique verso rem subicias;</li>
+                      </ol>
+                    </li>
+                  </ul>
+                </li>
+                <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+                <li>Conferam tecum, quam cuique verso rem subicias;
+                  <ol>
+                    <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                    <li>Conferam tecum, quam cuique verso rem subicias;
+                      <ul>
+                        <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                        <li>Conferam tecum, quam cuique verso rem subicias;
+                          <ul>
+                            <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                            <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?
+                              <ul>
+                                <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                                <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                                <li>Conferam tecum, quam cuique verso rem subicias;</li>
+                              </ul>
+                            </li>
+                            <li>Conferam tecum, quam cuique verso rem subicias;</li>
+                          </ul>
+                        </li>
+                        <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                        <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+                      </ul>
+                    </li>
+                    <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                    <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+                    <li>Aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                    <li>Poterant, defendebant sententiam suam.</li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>Sed eum qui audiebant, quoad poterant</li>
+            <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+            <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+            <li>Conferam tecum, quam cuique verso rem subicias;</li>
+          </ol>
+      </li>
+      <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+      <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+    </ol>
+  </div>
+</div>

--- a/src/stories/Scheme/LegalFormatting/readme.md
+++ b/src/stories/Scheme/LegalFormatting/readme.md
@@ -1,0 +1,22 @@
+<!-- This is the general documentation layout. Add or remove any sections as needed, but try to stay consistent across components. -->
+
+# LegalFormatting
+
+Description of the LegalFormatting styles in markdown.
+
+<details>
+  <summary>Inherited CSS Variables:</summary>
+  - `--name`: description...
+</details>
+
+<details>
+  <summary>Twig Variables:</summary>
+  ```
+  variant: "default",
+  ...,
+  sub_component_data: {
+    variant: "default",
+    ...
+  }
+  ```
+</details>

--- a/src/stories/Scheme/Text/Text.stories.js
+++ b/src/stories/Scheme/Text/Text.stories.js
@@ -1,0 +1,20 @@
+import readme from './readme.md';
+import Text from './Text.twig';
+
+export default {
+  title: 'Scheme/Text',
+  component: Text,
+  parameters: {
+    notes: readme,
+    layout: 'padded',
+  },
+};
+
+// Create Template for variant templates to bind to.
+const Template = ({ ...args }) => {
+  return Text({ ...args });
+};
+
+// Bind the Default component variant for this component.
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/stories/Scheme/Text/Text.twig
+++ b/src/stories/Scheme/Text/Text.twig
@@ -1,0 +1,83 @@
+{% set classes = [
+  'text',
+  'field',
+  'stack',
+] %}
+
+<div class="{{ classes|join(' ') }}" style="max-width: var(--measure);">
+  
+  <h1>Html text examples (h1)</h1>
+
+  <hr/>
+
+  <h2>Paragraph and basic text items examples (h2)</h2>
+
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Huius ego nunc auctoritatem sequens idem faciam. Qui enim voluptatem ipsam contemnunt, iis licet dicere se acupenserem maenae non anteponere. <strong>Nam ista vestra: Si gravis, brevis;</strong>Itaque quantum adiit periculum! ad honestatem enim illum omnem conatum suum referebat, non ad voluptatem. Nunc ita separantur, ut disiuncta sint, quo nihil potest esse perversius. Paria sunt igitur. Dolere malum est: in crucem qui agitur, beatus esse non potest. <a href="#" target="_blank">Esse potuerit</a> quae tandem ista ratio est? At coluit ipse amicitias. <em>Duo Reges: constructio interrete.</em> </p>
+
+  <h3>Quod autem principium officii quaerunt, melius quam Pyrrho (h3)</h3>
+
+  <p>Quod, inquit, quamquam voluptatibus quibusdam est saepe iucundius, tamen expetitur propter voluptatem. Et non ex maxima parte de tota iudicabis? Qui enim voluptatem ipsam contemnunt, iis licet dicere se acupenserem maenae non anteponere. <a href="#" target="_blank">Occultum facinus esse potuerit</a> Itaque quantum adiit periculum! ad honestatem enim illum omnem conatum suum referebat, non ad voluptatem. Nunc ita separantur, ut disiuncta sint, quo nihil potest esse perversius. Paria sunt igitur. Dolere malum est: in crucem qui agitur, beatus esse non potest. Sed quae tandem ista ratio est? At coluit ipse amicitias. Duo Reges: constructio interrete.</p>
+
+  <h4>Quod autem principium officii quaerunt, melius quam Pyrrho (h4)</h4>
+
+  <p>Itaque quantum adiit periculum! ad honestatem enim illum omnem conatum suum referebat, non ad voluptatem. Nunc ita separantur, ut disiuncta sint, quo nihil potest esse perversius. Paria sunt igitur. Dolere malum est: in crucem qui agitur, beatus esse non potest. Sed quae tandem ista ratio est? At coluit ipse amicitias. Duo Reges: constructio interrete.</p>
+
+  <hr/>
+
+  <h2>Ordered list</h2>
+  <ol>
+    <li>Quae autem natura suae primae institutionis oblita est?</li>
+    <li>Illud dico, ea, quae dicat, praeclare inter se cohaerere.</li>
+    <li>Que Manilium, ab iisque M.</li>
+    <li>Cuius etiam illi hortuli propinqui non memoriam solum mihi afferunt, sed ipsum videntur in conspectu meo ponere.</li>
+    <li>Perturbationes autem nulla naturae vi commoventur, omniaque ea sunt opiniones ac iudicia levitatis.</li>
+    <li>Roges enim Aristonem, bonane ei videantur haec: vacuitas doloris, divitiae, valitudo;</li>
+  </ol>
+
+  <hr/>
+
+  <h2>Unordered list</h2>
+  <ul>
+    <li>Illud dico, ea, quae dicat, praeclare inter se cohaerere.</li>
+    <li>Non est igitur voluptas bonum.</li>
+    <li>Non potes, nisi retexueris illa.</li>
+  </ul>
+
+  <hr/>
+
+  <h2>Definition list</h2>
+  <dl>
+    <dt><dfn>Verum audiamus.</dfn></dt>
+    <dd>Cupit enim dícere nihil posse ad beatam vitam deesse sapienti.</dd>
+    <dt><dfn>Etiam beatissimum?</dfn></dt>
+    <dd>Quod quidem nobis non saepe contingit.</dd>
+    <dt><dfn>Bork</dfn></dt>
+    <dd>Quodsi vultum tibi, si incessum fingeres, quo gravior viderere, non esses tui similis;</dd>
+  </dl>
+
+  <hr/>
+
+  <h2>Blockquote</h2>
+  <blockquote cite="http://loripsum.net">
+    Virtutis, magnitudinis animi, patientiae, fortitudinis fomentis dolor mitigari solet.
+  </blockquote>
+
+  <hr/>
+
+  <h2>Pre</h2>
+  
+  <pre>
+    Nec tamen ille erat sapiens quis enim hoc aut quando aut ubi aut unde? 
+    Quae animi affectio suum cuique tribuens atque hanc, quam dico.
+  </pre>
+
+  <hr/>
+
+  <h2>Code</h2>
+
+  <code> Nec tamen ille erat sapiens quis enim hoc aut quando aut ubi aut unde? Quae animi affectio suum cuique tribuens atque hanc, quam dico.</code>
+
+  <hr/>
+
+  <p><em>Add more examples here...</em></p>
+</div>

--- a/src/stories/Scheme/Text/readme.md
+++ b/src/stories/Scheme/Text/readme.md
@@ -1,0 +1,21 @@
+<!-- This is the general documentation layout. Add or remove any sections as needed, but try to stay consistent across components. -->
+# Text
+
+Description of the Text in markdown.
+
+<details>
+  <summary>Inherited CSS Variables:</summary>
+  - `--name`: description...
+</details>
+
+<details>
+  <summary>Twig Variables:</summary>
+  ```
+  variant: "default",
+  ...,
+  sub_component_data: {
+    variant: "default",
+    ...
+  }
+  ```
+</details>


### PR DESCRIPTION
[DCAS-36]

Added a setup to try to set ordered and unordered lists in a pre-formatted fashion. This sets the "markers" if the lists to be wrapped in parenthesis. Like (a), (i), (1), and (A).

Also added a 'Text' scheme component as an example of the basic styles for things like paragraphs, lists, links, headings, and other base html elements. Not useable in elements, but can show how the basic styles look.