### PR TITLE
[DCAS 54] -- Improved legal ordered list formatting for Drupal integration

### DIFF
--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -117,6 +117,103 @@ dd {
   margin-inline-start: var(--s1);
 }
 
+/* Legal formatting of Ordered lists. See @LegalFormatting component */
+@counter-style legal_decimal {
+  system: extends decimal;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+@counter-style legal_upper_roman {
+  system: extends upper-roman;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+@counter-style legal_upper_alpha {
+  system: extends upper-alpha;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+@counter-style legal_lower_roman {
+  system: extends lower-roman;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+@counter-style legal_lower_alpha {
+  system: extends lower-alpha;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+@counter-style legal_decimal_leading_zero {
+  system: extends decimal-leading-zero;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+ol.legal {
+  counter-reset: list;
+  list-style: legal_decimal;
+}
+
+ol.legal, ol.legal ol {
+  padding-inline: var(--s2);
+}
+
+ol.legal li + li {
+  margin-block-start: var(--s-6);
+}
+
+ol.legal li + li > ol,
+ol.legal li + li > ul {
+  margin-block: var(--s1);
+}
+
+ol.legal li::marker {
+  font-weight: 600;
+}
+
+ol.legal li li li li li ol > li {
+  list-style: legal_upper_roman;
+}
+
+ol.legal li li li li ol > li {
+  list-style: legal_upper_alpha;
+}
+
+ol.legal li li li ol > li {
+  list-style: legal_decimal_leading_zero;
+}
+
+ol.legal li li ol > li {
+  list-style: legal_lower_roman;
+}
+
+ol.legal li ol > li {
+  list-style: legal_decimal;
+}
+
+ol.legal > li {
+  list-style: legal_lower_alpha;
+}
+
+/* Legal formatting of Unordered lists. See @LegalFormatting component */
+ol.legal ul > li ul > li ul > li {
+  list-style-type: square;
+}
+
+ol.legal ul > li ul > li {
+  list-style-type: circle;
+}
+
+ol.legal li ul > li,
+ol.legal ul > li {
+  list-style-type: disc;
+}
+
 /* Screen Reader Only */
 .sr-only {
   position: absolute;

--- a/src/stories/Scheme/LegalFormatting/LegalFormatting.css
+++ b/src/stories/Scheme/LegalFormatting/LegalFormatting.css
@@ -1,71 +1,97 @@
 /* Ordered list styles */
-.legal ol {
-  counter-reset: list;
+
+@counter-style legal_decimal {
+  system: extends decimal;
+  prefix: '(';
+  suffix: ')  ';
 }
 
-.legal li + li {
+@counter-style legal_upper_roman {
+  system: extends upper-roman;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+@counter-style legal_upper_alpha {
+  system: extends upper-alpha;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+@counter-style legal_lower_roman {
+  system: extends lower-roman;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+@counter-style legal_lower_alpha {
+  system: extends lower-alpha;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+@counter-style legal_decimal_leading_zero {
+  system: extends decimal-leading-zero;
+  prefix: '(';
+  suffix: ')  ';
+}
+
+ol.legal {
+  counter-reset: list;
+  list-style: legal_decimal;
+}
+
+ol.legal, ol.legal ol {
+  padding-inline: var(--s2);
+}
+
+ol.legal li + li {
   margin-block-start: var(--s-6);
 }
 
-.legal li + li > ol,
-.legal li + li > ul {
+ol.legal li + li > ol,
+ol.legal li + li > ul {
   margin-block: var(--s1);
 }
 
-.legal ol > li {
-  list-style: none;
-}
-
-.legal ol li::marker,
-.legal ul li::marker {
+ol.legal li::marker {
   font-weight: 600;
 }
 
-.legal ol > li:before {
-  width: var(--s2);
-  display: inline-block;
-  margin-inline-start: calc(var(--s2) * -1);
-  margin-inline-end: var(--s-3);
-  font-weight: 600;
-  text-align: end;
-  counter-increment: list;
-  content: "(" counter(list, lower-alpha) ")";
+ol.legal li li li li li ol > li {
+  list-style: legal_upper_roman;
 }
 
-.legal li li li li li ol > li:before {
-  content: "(" counter(list, upper-roman) ")";
+ol.legal li li li li ol > li {
+  list-style: legal_upper_alpha;
 }
 
-.legal li li li li ol > li:before {
-  content: "(" counter(list, upper-alpha) ")";
+ol.legal li li li ol > li {
+  list-style: legal_decimal_leading_zero;
 }
 
-.legal li li li ol > li:before {
-  content: "(" counter(list, decimal-leading-zero) ")";
+ol.legal li li ol > li {
+  list-style: legal_lower_roman;
 }
 
-.legal li li ol > li:before {
-  content: "(" counter(list, lower-roman) ")";
+ol.legal li ol > li {
+  list-style: legal_decimal;
 }
 
-.legal li ol > li:before {
-  content: "(" counter(list, decimal) ")";
-}
-
-.legal ol > li:before {
-  content: "(" counter(list, lower-alpha) ")";
+ol.legal > li {
+  list-style: legal_lower_alpha;
 }
 
 /* Unordered list styles */
-.legal ul > li ul > li ul > li {
-  list-style-type: circle;
-}
-
-.legal ul > li ul > li {
+ol.legal ul > li ul > li ul > li {
   list-style-type: square;
 }
 
-.legal li ul > li,
-.legal ul > li {
+ol.legal ul > li ul > li {
+  list-style-type: circle;
+}
+
+ol.legal li ul > li,
+ol.legal ul > li {
   list-style-type: disc;
 }

--- a/src/stories/Scheme/LegalFormatting/LegalFormatting.twig
+++ b/src/stories/Scheme/LegalFormatting/LegalFormatting.twig
@@ -8,80 +8,78 @@
 
   <h2>Legal formatted list items</h2>
 
-  <p>The class <strong>"legal"</strong> needs to be applied to some parent of the
-  list to trigger the "Legal" styles. This is a mixed example of nested ordered 
-  and unordered list items</p>
+  <p>The class <strong>"legal"</strong> needs to be applied to highest/first level ordered list to trigger the
+    "Legal" styles. This is a mixed example of nested ordered items with unordered list items integrated within.</p>
 
-  <div class="legal">
-    <ol>
-      <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-      <li>Conferam tecum, quam cuique verso rem subicias;
-        <ol>
-            <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-            <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?
-              <ol>
-                <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-                <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
-                <li>Conferam tecum, quam cuique verso rem subicias;</li>
-              </ol>
-            </li>
-            <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
-            <li>Conferam tecum, quam cuique verso rem subicias;
-              <ol>
-                <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-                <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?
-                  <ul>
-                    <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-                    <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
-                    <li>Conferam tecum, quam cuique verso rem subicias;
-                      <ol>
-                        <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-                        <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
-                        <li>Conferam tecum, quam cuique verso rem subicias;</li>
-                      </ol>
-                    </li>
-                  </ul>
-                </li>
-                <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
-                <li>Conferam tecum, quam cuique verso rem subicias;
-                  <ol>
-                    <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-                    <li>Conferam tecum, quam cuique verso rem subicias;
-                      <ul>
-                        <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-                        <li>Conferam tecum, quam cuique verso rem subicias;
-                          <ul>
-                            <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-                            <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?
-                              <ul>
-                                <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-                                <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
-                                <li>Conferam tecum, quam cuique verso rem subicias;</li>
-                              </ul>
-                            </li>
-                            <li>Conferam tecum, quam cuique verso rem subicias;</li>
-                          </ul>
-                        </li>
-                        <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
-                        <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
-                      </ul>
-                    </li>
-                    <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
-                    <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
-                    <li>Aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
-                    <li>Poterant, defendebant sententiam suam.</li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li>Sed eum qui audiebant, quoad poterant</li>
-            <li>Summum ením bonum exposuit vacuitatem doloris;</li>
-            <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
-            <li>Conferam tecum, quam cuique verso rem subicias;</li>
-          </ol>
-      </li>
-      <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
-      <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
-    </ol>
-  </div>
+  <ol class="legal">
+    <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+    <li>Conferam tecum, quam cuique verso rem subicias;
+      <ol>
+          <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+          <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?
+            <ol>
+              <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+              <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+              <li>Conferam tecum, quam cuique verso rem subicias;</li>
+            </ol>
+          </li>
+          <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+          <li>Conferam tecum, quam cuique verso rem subicias;
+            <ol>
+              <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+              <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?
+                <ul>
+                  <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                  <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                  <li>Conferam tecum, quam cuique verso rem subicias;
+                    <ol>
+                      <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                      <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                      <li>Conferam tecum, quam cuique verso rem subicias;</li>
+                    </ol>
+                  </li>
+                </ul>
+              </li>
+              <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+              <li>Conferam tecum, quam cuique verso rem subicias;
+                <ol>
+                  <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                  <li>Conferam tecum, quam cuique verso rem subicias;
+                    <ul>
+                      <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                      <li>Conferam tecum, quam cuique verso rem subicias;
+                        <ul>
+                          <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                          <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?
+                            <ul>
+                              <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+                              <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                              <li>Conferam tecum, quam cuique verso rem subicias;</li>
+                            </ul>
+                          </li>
+                          <li>Conferam tecum, quam cuique verso rem subicias;</li>
+                        </ul>
+                      </li>
+                      <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                      <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+                    </ul>
+                  </li>
+                  <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                  <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+                  <li>Aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+                  <li>Poterant, defendebant sententiam suam.</li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>Sed eum qui audiebant, quoad poterant</li>
+          <li>Summum ením bonum exposuit vacuitatem doloris;</li>
+          <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+          <li>Conferam tecum, quam cuique verso rem subicias;</li>
+        </ol>
+    </li>
+    <li>Quis animo aequo videt eum, quem inpure ac flagitiose putet vivere?</li>
+    <li>Sed eum qui audiebant, quoad poterant, defendebant sententiam suam.</li>
+  </ol>
+  
 </div>

--- a/src/stories/Scheme/LegalFormatting/readme.md
+++ b/src/stories/Scheme/LegalFormatting/readme.md
@@ -4,5 +4,5 @@
 
 Some lists need to have a specific formatting applied to match what is expected and preferred in legal documents.
 
-The class **legal** needs to be applied to some parent of the list to trigger the
-"Legal" styles. This is a mixed example of nested ordered and unordered list items.
+The class **legal** needs to be applied to highest/first level ordered list to trigger the
+"Legal" styles. This is a mixed example of nested ordered items with unordered list items integrated within.


### PR DESCRIPTION
Improved legal ordered list formatting for Drupal integration.

- Changed style start to work from a starting ordered list (ol) with legal class, instead of trying to apply the legal to a parent div. This will work better with the way Ckeditor controls list styles in Drupal.
- Used @counter-styles to implement specific legal ordered list styles.
- Copied legal formatting styles to main elements.css file to bring them in globally. Still need to figure out better way to bring this into the site when ckeditor calls for it.