### PR TITLE
[DCAS-46] -- Tweak to the way the background color order is applied to the nav items of a hero.

### DIFF
--- a/src/stories/Molecules/Hero/Hero.css
+++ b/src/stories/Molecules/Hero/Hero.css
@@ -91,19 +91,19 @@
 }
 
 /* Automated nav button colors */
-.hero__navigation.cards .card:nth-of-type(6n + 1) {
-  background: var(--background-striped-secondary);
-}
-
-.hero__navigation.cards .card:nth-of-type(6n + 2) {
-  background: var(--background-striped-primary-dark-x);
-}
-
-.hero__navigation.cards .card:nth-of-type(6n + 3) {
+.hero__navigation.cards .card:nth-of-type(odd) {
   background: var(--background-striped-primary);
 }
 
-.hero__navigation.cards .card:nth-of-type(6n + 4) {
+.hero__navigation.cards .card:nth-of-type(even) {
+  background: var(--background-striped-primary-dark-x);
+}
+
+.hero__navigation.cards .card:first-child:not(.card:last-child) {
+  background: var(--background-striped-secondary);
+}
+
+.hero__navigation.cards .card:last-child:not(.card:nth-of-type(2), .card:first-child) {
   background: var(--background-striped-accent-warm-dark-x);
 }
 


### PR DESCRIPTION
[DCAS-46] -- Tweak to the way the background color order is applied to the nav items of a hero.

- Sets the first item to be the striped secondary (green in this case) 
- Sets the second and subsequent even items to be the striped primary darkX (dark blue in this case) 
- Sets the third and subsequent odd items to be the striped primary (light blue in this case) 
- Sets the last item, usually fourth to be the striped accent warm darkX (orange in this case)

**Special instances:**
- if only 1 item: it does not set the secondary or warm accent of the first and last item, it just sets the primary dark (dark blue). 
- If only 2 items: it does not set the last item as the warm accent/orange, but sets the first with the secondary (green). 
- If only 3 items: it does not set the third item as the light blue, but as the warm accent/orange.

This setup follows the way the background colors of the items were defined in figma depending on how many menu items there were.