### PR TITLE
[DCAS-60] -- On desktop, the parent link was not working as link when hover state is set.

### DIFF
--- a/src/stories/Molecules/PrimaryNav/PrimaryNav.css
+++ b/src/stories/Molecules/PrimaryNav/PrimaryNav.css
@@ -109,7 +109,14 @@ button.primary-nav__button {
   padding: 0 0 0 0;
 }
 
+.primary-nav__mobile .primary-nav__item a.primary-nav__overview-link,
+.primary-nav__mobile .primary-nav__item button.primary-nav__overview-link {
+  font-size: var(--s-1);
+}
+
+.primary-nav a.primary-nav__button.parent_link::after,
 .primary-nav button::after {
+  margin-inline-start: var(--s-5);
   align-self: center;
   content: "\25BE";
   color: var(--color-base-light-x);
@@ -137,6 +144,7 @@ button.primary-nav__button.active {
   content: none;
 }
 
+.primary-nav .parent_link + *,
 .primary-nav button + * {
   display: none;
   min-width: 18ch;
@@ -206,10 +214,6 @@ button.primary-nav__button.active {
   max-width: none;
   width: 100%;
 }
-
-/* .primary-nav__item--mega .grid :first-child{
-  grid-column: 1 / -1;
-} */
 
 .primary-nav__default button + .primary-nav__item--mega a {
   border: 0;
@@ -442,4 +446,12 @@ button.primary-nav__button.active {
 .primary-nav__desktop .primary-nav__group:focus-within .primary-nav__item {
   display: block;
   position: absolute;
+}
+
+.primary-nav__desktop .primary-nav__group.primary-nav__has-overview-link .primary-nav__link:not(.primary-nav__overview-link) {
+  margin-inline-start: var(--s-1);
+}
+
+.primary-nav__desktop .primary-nav__item--mega .grid .link-level-2__has-overview-link {
+  grid-column: 1 / -1;
 }

--- a/src/stories/Molecules/PrimaryNav/PrimaryNav.data.js
+++ b/src/stories/Molecules/PrimaryNav/PrimaryNav.data.js
@@ -1,6 +1,7 @@
 export default {
   default: {
     variant: "default",
+    desktop_dropdown_overview_link: false,
     header_search_data: {
       variant: "default",
       form: "<form action='/search' class='header-search__form' role='search'><label class='sr-only' for='header-search'>Search</label><input id='header-search' type='search' name='search' placeholder='Search' /><button class='header-search__icon' type='submit'><span class='header-search__search-line'></span><span class='header-search__search-circle'></span><span class='sr-only'>Search</span></button></form>",
@@ -22,9 +23,10 @@ export default {
       },
       {
         text: "Up To Seven",
+        url: "#",
         links: [
           {
-            text: "Navigation link 1 (Overview)",
+            text: "Navigation link 1",
             url: "#",
             is_overview_link: true,
           },
@@ -61,9 +63,10 @@ export default {
       },
       {
         text: "More Than Seven",
+        url: "#",
         links: [
           {
-            text: "Navigation link 1 (Overview)",
+            text: "Navigation link 1",
             url: "#",
             is_overview_link: true,
           },
@@ -118,9 +121,10 @@ export default {
       },
       {
         text: "Lots More",
+        url: "#",
         links: [
           {
-            text: "Navigation link 1 (Overview)",
+            text: "Navigation link 1",
             url: "#",
             is_overview_link: true,
           },
@@ -392,6 +396,7 @@ export default {
   },
   alternate: {
     variant: "alternate",
+    desktop_dropdown_overview_link: false,
     header_search_data: {
       variant: "",
       form: "",

--- a/src/stories/Molecules/PrimaryNav/PrimaryNav.twig
+++ b/src/stories/Molecules/PrimaryNav/PrimaryNav.twig
@@ -1,3 +1,6 @@
+{# Define if the top level includes a an overview link in the dropdown #}
+{% set has_desktop_dropdown_overview_link = desktop_dropdown_overview_link|default(false) %}
+
 {# Set up variant classes. #}
 {% set variant_class = variant ? 'primary-nav--' ~ variant : 'primary-nav--default' %}
 
@@ -12,9 +15,14 @@
     {% for i,link in links %}
       {% set parent = link.links is not empty ? true : false %}
 
-      <div class="primary-nav__group">
+      {% set parent_overview_link_class = has_desktop_dropdown_overview_link ? 'primary-nav__has-overview-link' : '' %}
+      <div class="primary-nav__group {{ parent_overview_link_class }}">
         {% if parent %}
-          <button class="primary-nav__button button">{{ link.text }}</button>
+          {% if has_desktop_dropdown_overview_link %}
+            <button class="primary-nav__button button">{{ link.text }}</button>
+          {% else %}
+            {{ link(link.text, link.url, {class: ['primary-nav__button parent_link']}) }}
+          {% endif %}
         {% else %}
           {{ link(link.text, link.url, {class: ['primary-nav__button']}) }}
         {% endif %}
@@ -29,8 +37,10 @@
                     'link',
                     'link-level-2',
                     link2.is_current ? 'is_current' : '',
+                    (link2.is_overview_link) and (has_desktop_dropdown_overview_link) ? 'link-level-2__has-overview-link' : null,
                   ] %}
-									<span class="{{ link2_classes|join(' ') }}">{{ link(link2.text, link2.url, {class: ['primary-nav__link']}) }}</span>
+                  {% set overview_link_class = (link2.is_overview_link) and (has_desktop_dropdown_overview_link) ? 'primary-nav__overview-link' : null %}
+									<span class="{{ link2_classes|join(' ') }}">{{ link(link2.text, link2.url, {class: ['primary-nav__link', overview_link_class]}) }}</span>
 								{% endfor %}
 							</div>
 						</div>


### PR DESCRIPTION
[DCAS-60]

On desktop, the parent link was not working as link when hover state is set.

This fix better responds to the desktop output of the main level links and sets better classes to make the desktop menu more aware of when it has or doesn't have an overview link setup.