### PR TITLE
[Update] - Spacing style fixes for heading tags in body type content.

### DIFF
--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -55,6 +55,18 @@ p {
 }
 
 p + p {
+  margin-block-start: var(--s0);
+}
+
+:where(p, h2, h3, h4, h5, h6) + h2,
+:where(p, h2, h3, h4, h5, h6) + h3,
+:where(p, h2, h3, h4, h5, h6) + h4,
+:where(p, h2, h3, h4, h5, h6) + h5,
+:where(p, h2, h3, h4, h5, h6) + h6 {
+  margin-block-start: var(--gap, 1.5rem);
+}
+
+:where(p, h2, h3, h4, h5, h6) + p {
   margin-top: var(--s0);
 }
 

--- a/src/stories/Molecules/Accordion/Accordion.css
+++ b/src/stories/Molecules/Accordion/Accordion.css
@@ -55,6 +55,7 @@
   padding-inline-end: var(--s1);
   list-style-type: none;
   cursor: pointer;
+  align-items: center;
 }
 
 .accordion details > summary::-webkit-details-marker {

--- a/src/stories/Molecules/Accordion/Accordion.data.js
+++ b/src/stories/Molecules/Accordion/Accordion.data.js
@@ -12,21 +12,21 @@ export default {
         label:
           "What is the Judicial Council of California's role in the current court interpreter program?",
         content:
-          "<p>This is text in a paragraph. This content can realistically be any type of content. Cards, Sections, Media...any rendered content could be passed in.</p> <p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p>",
+          "<p>This is text in a paragraph. This content can realistically be any type of content. Cards, Sections, Media...any rendered content could be passed in.</p> <p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu. blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu. blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p> <h3>Elit penatibus dignissim placerat</h3> <h4> Ac non lacus sollicitudin</h4><p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p> <p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p>",
       },
       {
         id: "which_judicial_council_panel_oversees_the_court_interpreters_program",
         label:
           "Which Judicial Council panel oversees the court interpreters program?",
         content:
-          "<p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p>",
+          "<p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p> <h3>Ac non lacus sollicitudin</h3> <p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p> <p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p> <p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p>",
       },
       {
         id: "how_can_courts_identify_certified_or_registered_court_interpreters",
         label:
           "How can courts identify certified or registered court interpreters?",
         content:
-          "<p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare.</p>",
+          "<p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare.</p> <p>Lorem ipsum dolor sit amet consectetur adipiscing, elit penatibus dignissim placerat ante vulputate, blandit donec enim senectus ornare. Ac non lacus sollicitudin vulputate sociosqu.</p>",
       },
     ],
   },

--- a/src/stories/Molecules/Body/Body.data.js
+++ b/src/stories/Molecules/Body/Body.data.js
@@ -1,9 +1,24 @@
+
+let body_content = [
+  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quod quidem iam fit etiam in Academia. Prave, nequiter, turpiter cenabat; Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</p>",
+  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quod quidem iam fit etiam in Academia. Prave, nequiter, turpiter cenabat; Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</p>",
+  "<h2>This is a second level heading</h2>",
+  "<h3>This is a third level heading</h3>",
+  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere. Quod quidem iam fit etiam in Academia. Prave, nequiter, turpiter cenabat; Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</p>",
+  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quod quidem iam fit etiam in Academia. Prave, nequiter, turpiter cenabat; Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</p>",
+  "<h3>This is a third level heading</h3>",
+  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quod quidem iam fit etiam in Academia. Prave, nequiter, turpiter cenabat; Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</p>",
+  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quod quidem iam fit etiam in Academia. Prave, nequiter, turpiter cenabat; Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</p>",
+  "<h4>This is a fourth level heading</h4>",
+  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quod quidem iam fit etiam in Academia. Prave, nequiter, turpiter cenabat; Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</p>",
+];
+
 export default {
   default: {
     variant: "default",
     heading: "Body component goes here.",
     lead: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quod quidem iam fit etiam in Academia.</p>",
-    content: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quod quidem iam fit etiam in Academia. Prave, nequiter, turpiter cenabat; Neque enim civitas in seditione beata esse potest nec in discordia dominorum domus; Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</p>",
+    content: body_content.join(' '),
     subheading: "This is a subheading.",
     aside: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quod quidem iam fit etiam in Academia.</p>",
   },

--- a/src/stories/Molecules/Tabs/Tabs.data.js
+++ b/src/stories/Molecules/Tabs/Tabs.data.js
@@ -4,7 +4,7 @@ export default {
     items: [
       {
         label: "Working With Interpreters",
-        content: "Any rendered content goes here. Lorem ipsum dolor sit amet consectetur adipiscing elit aenean tincidunt erat fames, tempor laoreet a facilisis nam aliquet nisi tellus. Lorem ipsum dolor sit amet consectetur adipiscing elit aenean tincidunt erat fames, tempor laoreet a facilisis nam aliquet nisi tellus. Lorem ipsum dolor sit amet consectetur adipiscing elit aenean tincidunt erat fames, tempor laoreet a facilisis nam aliquet nisi tellus. Lorem ipsum dolor sit amet consectetur adipiscing elit aenean tincidunt erat fames, tempor laoreet a facilisis nam aliquet nisi tellus",      },
+        content: "<p>Any rendered content goes here. Lorem ipsum dolor sit amet consectetur adipiscing elit aenean tincidunt erat fames</p> <h3>Tempor laoreet a facilisis nam aliquet nisi tellus.</h3> <h4>Sit amet consectetur adipiscing</h4> <p>Lorem ipsum dolor sit amet consectetur adipiscing elit aenean tincidunt erat fames, tempor laoreet a facilisis nam aliquet nisi tellus. Lorem ipsum dolor sit amet consectetur adipiscing elit aenean tincidunt erat fames, tempor laoreet a facilisis nam aliquet nisi tellus. Lorem ipsum dolor sit amet consectetur adipiscing elit aenean tincidunt erat fames, tempor laoreet a facilisis nam aliquet nisi tellus</p>",      },
       {
         label: "Information about Court Processess",
         content: "Any rendered content goes here. Lorem ipsum dolor sit amet consectetur adipiscing elit aenean tincidunt erat fames, tempor laoreet a facilisis nam aliquet nisi tellus.",


### PR DESCRIPTION
Spacing style fixes for heading tags in body type content. H2-h6 tags in body type (wysiwyg) content was not spacing correctly. Stack class on the wrapping template was adding too much spacing.