### PR TITLE
[DCAS-166] -- Alter the ResultExcerpt component to help address some twig/php notices and warnings showing in the logs

### DIFF
--- a/src/stories/Molecules/ResultExcerpt/ResultExcerpt.css
+++ b/src/stories/Molecules/ResultExcerpt/ResultExcerpt.css
@@ -1,7 +1,7 @@
 .result-excerpt__header {
   overflow: hidden;
   /* align-items: center; */
-  --gap: var(--s1)
+  --gap: var(--s1);
 }
 
 .result-excerpt__brow {
@@ -46,12 +46,13 @@
 /* Media headings must always appear as H4 visually. */
 .result-excerpt__heading {
   font-size: var(--s1);
+  line-height: var(--s3);
 }
 
 .result-excerpt__button {
   /* Negative margin hides border when wrapped. */
   /* margin-inline-start: -1px; */
-  border-inline-start: 1px solid var(--color-base);
+  /* border-inline-start: 1px solid var(--color-base); */
   padding-inline: var(--s1);
   display: flex;
   flex-shrink: 1;
@@ -71,7 +72,7 @@
 }
 
 .result-excerpt__content {
-  margin-block-start: var(--s-6);
+  margin-block-start: var(--s0);
 }
 
 .result-excerpt__content.stack > * + * {

--- a/src/stories/Molecules/ResultExcerpt/ResultExcerpt.data.js
+++ b/src/stories/Molecules/ResultExcerpt/ResultExcerpt.data.js
@@ -1,6 +1,6 @@
 // import '../../../js/detectWrap.js';
-import Pills from "../../Molecules/Pills/Pills.twig";
-import { Default as PillsDefault } from "../../Molecules/Pills/Pills.stories";
+import Pill from "../../Atoms/Pill/Pill.twig";
+import { Default as PillDefault } from "../../Atoms/Pill/Pill.stories";
 
 export default {
   default: {
@@ -32,6 +32,17 @@ export default {
         "Report",
       ],
     },
-    pills: Pills({ ...PillsDefault.args }),
+    pills: {
+      variant: "default",
+      icon_data: {
+        icon: "translation",
+        color: false,
+      },
+      items: [
+        Pill({ ...PillDefault.args }),
+        Pill({ ...PillDefault.args }),
+        Pill({ ...PillDefault.args }),
+      ],
+    },
   },
 };

--- a/src/stories/Molecules/ResultExcerpt/ResultExcerpt.twig
+++ b/src/stories/Molecules/ResultExcerpt/ResultExcerpt.twig
@@ -44,7 +44,7 @@
   
   {% if detail_list_data or pills or content %}
     <div class="result-excerpt__content stack">
-      {{ content }}
+      <div>{{ content }}</div>
       
       {% if detail_list_data or pills %}
         {% if detail_list_data %}

--- a/src/stories/Molecules/ResultExcerpt/ResultExcerpt.twig
+++ b/src/stories/Molecules/ResultExcerpt/ResultExcerpt.twig
@@ -61,7 +61,7 @@
         {% endif %}
         {% if pills %}
         <div class="result-excerpt__pills">
-          {{ pills }}
+          {% include "@molecules/Pills/Pills.twig" with pills %}
         </div>
         {% endif %}
       {% endif %}


### PR DESCRIPTION
[DCAS-166]

Alter the ResultExcerpt component to help address some twig/php notices and warnings showing in the logs.

Moving Pills theming into the template helps prevent an associative array inside of an associative array which is the cause of all the warnings

Additional, removed the vertical border between the title and button of the component.