### PR TITLE
DCAS-274: add subsection white text support

### DIFF
--- a/src/stories/Organisms/Section/Section.css
+++ b/src/stories/Organisms/Section/Section.css
@@ -116,21 +116,21 @@
 }
 
 /* Variants */
-.section--color-primary-dark-xx {
+.section--color-primary-dark-xx,
+.section--color-primary-dark-xx .section,
+.section--color-primary-dark-xx-stripe,
+.section--color-primary-dark-xx-stripe .section {
   --color: var(--color-white);
   --accent-color: var(--color-accent-warm-light-x);
   --heading-color: var(--color-white);
   --button-fg: var(--accent-color);
+}
 
+.section--color-primary-dark-xx {
   background: var(--color-primary-dark-xx);
 }
 
 .section--color-primary-dark-xx-stripe {
-  --color: var(--color-white);
-  --accent-color: var(--color-accent-warm-light-x);
-  --heading-color: var(--color-white);
-  --button-fg: var(--accent-color);
-
   background: repeating-linear-gradient(
     125deg,
     #2f505e,


### PR DESCRIPTION
Text color handling on dark color section backgrounds was being trumped by subsections. Needed to override the subsection text color when in use (e.g., cards within a section).