### PR TITLE
[DCAS-271] -- Platform update: Visited Link color doesn't change when a link has been clicked

### DIFF
--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -49,6 +49,10 @@ a {
   color: var(--color-primary-light-x);
 }
 
+a:visited {
+  color: var(--color-primary-dark-x);
+}
+
 a:focus,
 a:focus-visible {
   outline: var(--border-color, var(--color-accent-warm-light-x)) auto var(--s-6);

--- a/src/stories/Atoms/Button/Button.css
+++ b/src/stories/Atoms/Button/Button.css
@@ -28,6 +28,10 @@
   background: var(--color-accent-warm-light-xxxx);
 }
 
+.button:visited {
+  color: var(--color-red);
+}
+
 .button:focus {
   outline: 2px solid var(--color-accent-warm-light-x);
   outline-offset: 2px;


### PR DESCRIPTION
[DCAS-271]

Platform update: Visited Link color doesn't change when a link has been clicked.

visited links set to a darker blue then the primary light blue that is default for links. Visited buttons are set to the dark red color.