### PR TITLE
[DCAS-281] -- Css fix to small sized email icon.

### DIFF
--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -263,3 +263,9 @@ ol.legal ul > li {
 .disclaimer-content > h3{
   font-size: var(--s1);
 }
+
+/* External links module css fix */
+svg.mailto {
+  width: 27px;
+  height: 17px;
+}


### PR DESCRIPTION
[DCAS-281]

Css fix to small sized email icon, the icon that comes from the external_links module.