### PR TITLE
fixed the order issue and adjusted the hidden behaviour

### DIFF
--- a/src/stories/Molecules/PrimaryNav/PrimaryNav.css
+++ b/src/stories/Molecules/PrimaryNav/PrimaryNav.css
@@ -200,7 +200,7 @@
 .primary-nav .primary-nav__group .icon-wrapper {
   width: var(--s-4);
   height: var(--s-4);
-  color: var(--color-base-light-x);
+  color: var(--color-base-dark-x);
 }
 
 .primary-nav .primary-nav__group:focus-within .icon-wrapper,

--- a/src/stories/Organisms/Header/Header.css
+++ b/src/stories/Organisms/Header/Header.css
@@ -167,24 +167,13 @@
 }
 
 /* Hide the header lower if the header upper triggers */
-.header .header__upper:has( > .container > .cluster.wrapping) ~ .header__lower,
-.header .header__upper:has( > .container > .cluster.wrapping) ~ .header__lower * {
-  height: 0;
-  padding: 0;
-  max-height: 0;
-  min-height: 0;
-  visibility: hidden;
-  flex-wrap: wrap;
+.header .header__upper:has( > .container > .cluster.wrapping) ~ .header__lower {
+  display: none;
 }
 
 /* Hide the header upper if the header lower triggers */
-.header:has(.header__lower .primary-nav .reel.overflowing) .header__upper .header__secondary,
-.header:has(.header__lower .primary-nav .reel.overflowing) .header__upper .header__secondary * {
-  height: 0;
-  padding: 0;
-  max-height: 0;
-  min-height: 0;
-  visibility: hidden;
+.header:has(.header__lower .primary-nav .reel.overflowing) .header__upper .header__secondary {
+  display: none;
 }
 
 /* Hide mobile menu section by default */

--- a/src/stories/Organisms/Header/Header.twig
+++ b/src/stories/Organisms/Header/Header.twig
@@ -17,9 +17,6 @@
         {% include "@atoms/SiteBranding/SiteBranding.twig" with site_branding_data %}
         {% if secondary_nav_data is not empty or translate or header_search_data %}
           <div class="header__secondary cluster detect-wrap detect-wrap--observed">
-            {% if header_search_data %}
-              {% include "@molecules/HeaderSearch/HeaderSearch.twig" with header_search_data %}
-            {% endif %}
             {% if translate %}
               <div class="header__secondary__translate">
               {% for feature in translate %}
@@ -31,6 +28,9 @@
               <div class="header__secondary-nav">
                 {% include "@molecules/SecondaryNav/SecondaryNav.twig" with secondary_nav_data %}
               </div>
+            {% endif %}
+            {% if header_search_data %}
+              {% include "@molecules/HeaderSearch/HeaderSearch.twig" with header_search_data %}
             {% endif %}
           </div>
         {% endif %}


### PR DESCRIPTION
Reordered markup in web/themes/contrib/jcc_storybook/src/stories/Organisms/Header/Header.twig:

Inside .header__secondary, SecondaryNav now renders before HeaderSearch.
Resulting tab order after logo is now: links (Find your court, Newsroom, Self-help) then search.
Adjusted hiding behavior in web/themes/contrib/jcc_storybook/src/stories/Organisms/Header/Header.css:

Replaced “visually hidden but still present” collapse rules for header sections with display: none in the triggered hidden states:
.header__lower hidden state
.header__upper .header__secondary hidden state
This prevents hidden sections from remaining interactive.