### PR TITLE
bugfixing ada-302

### DIFF
--- a/src/stories/Molecules/Accordion/Accordion.twig
+++ b/src/stories/Molecules/Accordion/Accordion.twig
@@ -22,8 +22,8 @@
 
     {% if expand_button %}
       <div class="expand-btns">
-        <a class="expand-all-btn expand button button--text button--normal no-arrow" aria-pressed="false" title="Toggle accordions" role="button" tabindex="0"> Expand all</a>
-        <a class="expand-all-btn close button button--text button--normal no-arrow" aria-pressed="false" title="Toggle accordions" role="button" tabindex="0">Close all</a>
+        <button type="button" class="expand-all-btn expand button button--text button--normal no-arrow">Expand all</button>
+        <button type="button" class="expand-all-btn close button button--text button--normal no-arrow">Close all</button>
       </div>
     {% endif %}
     <div class="accordion__items" open_on_load="{{ open_on_load }}">


### PR DESCRIPTION
The issue:  "Expand all" and "Close all" are actions, not navigation, so they should use native <button> elements instead of <a role="button">. 

The fix:
Replacing <a> with <button> provides the correct semantics and native keyboard support out of the box. Buttons are automatically focusable and activate with both Enter and Space, eliminating the need for role="button", tabindex, and custom keyboard behavior.